### PR TITLE
Adjusted cpp min/max Float values

### DIFF
--- a/src/be/Constant.hx
+++ b/src/be/Constant.hx
@@ -19,7 +19,7 @@ typedef Ints = I;
         #elseif java
         return untyped __java__('Double.MIN_VALUE');
         #elseif cpp
-        return 2.2250738585072e-308;
+	return 2.2250738585072014E-308;
         #elseif hl
         // Should be the MIN IEEE double precison float.
         // @see https://haxe.org/blog/hashlink-in-depth-p2/

--- a/src/be/Constant.hx
+++ b/src/be/Constant.hx
@@ -43,7 +43,7 @@ typedef Ints = I;
         #elseif java
         return untyped __java__('Double.MAX_VALUE');
         #elseif cpp
-        return 1.79769313486232e+308;
+	return 1.7976931348623157E+308;
         #elseif hl
         return 3.4028234664e+38;
         #elseif python


### PR DESCRIPTION
The min and max values for Float when compiling for cpp were slightly off.  The max value was rounded up which caused a -Wliteral-range warning on macOS and a C2177 error on Windows/Visual Studio.  While I was researching this I noticed that the min Float value was rounded down a tiny bit.  Corrected both.